### PR TITLE
Improves symlink handling during force linking.

### DIFF
--- a/link.zsh
+++ b/link.zsh
@@ -16,10 +16,16 @@ create_symlink() {
     # Handle existing files/directories
     if [[ -e "$target" || -L "$target" ]]; then
         if $force; then
-            # Create backup with timestamp
-            backup_target="${target}.backup.$(date +%Y%m%d_%H%M%S)"
-            mv "$target" "$backup_target"
-            echo "Backed up $target to $backup_target"
+            # Only backup if it's not a symlink (has actual content)
+            if [[ ! -L "$target" ]]; then
+                backup_target="${target}.backup.$(date +%Y%m%d_%H%M%S)"
+                mv "$target" "$backup_target"
+                echo "Backed up $target to $backup_target"
+            else
+                # Just remove symlink without backup
+                rm "$target"
+                echo "Removed existing symlink: $target"
+            fi
         else
             echo "$target already exists. Skipped."
             return


### PR DESCRIPTION
Refines the force linking functionality to handle existing symlinks more efficiently.

When the `force` option is enabled, the script now removes existing symlinks without creating a backup, streamlining the process and preventing unnecessary backup files for symlinks. Existing files or directories are still backed up as before.