### PR TITLE
Adds alacritty-theme submodule and configures theme

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,3 +1,8 @@
+[general]
+import = [
+    "~/.config/alacritty/theme/themes/monokai_pro.toml",
+]
+
 [window]
 dimensions = { columns = 140, lines = 40 }
 padding = { x = 8, y = 4 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".config/alacritty/theme"]
+	path = .config/alacritty/theme
+	url = https://github.com/alacritty/alacritty-theme.git


### PR DESCRIPTION
Adds the alacritty-theme submodule to manage terminal themes.

Configures Alacritty to import the monokai_pro theme.