### PR TITLE
fix: remove fzf ghost submodule and ignore vim-plug directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vim/.netrwhist
+.vim/plugged/


### PR DESCRIPTION
.vim/plugged/fzf was tracked as a submodule in the git index but had no entry in .gitmodules, causing "no submodule mapping found" errors. Remove it from the index and add .vim/plugged/ to .gitignore since vim-plug manages that directory independently.