### PR TITLE
Update .zshrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vim/.netrwhist
+.vim/plugged/

--- a/.zshrc
+++ b/.zshrc
@@ -40,3 +40,4 @@ fi
 
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
 
+source /Users/cybergene/.config/op/plugins.sh


### PR DESCRIPTION
This pull request makes a minor update to your shell configuration by sourcing an additional plugin script in `.zshrc`. It also removes the submodule reference for the `fzf` plugin in your `.vim` directory.

Shell configuration:

* Added a line to `.zshrc` to source the `op/plugins.sh` script, which may add or configure additional shell plugins.

Vim plugin management:

* Removed the submodule commit reference for the `fzf` plugin in `.vim/plugged/fzf`, which may indicate the plugin is no longer tracked as a submodule.