### PR TITLE
feat: Alacritty に Shift+Enter キーバインドを追加

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -25,3 +25,8 @@ blink_timeout = 30
 
 [mouse]
 hide_when_typing = true
+
+[[keyboard.bindings]]
+key = "Return"
+mods = "Shift"
+chars = "\u001B\r"


### PR DESCRIPTION
## Summary

Claude Code の `terminal-init` によって自動追加された設定。

- `alacritty.toml` に末尾改行を追加
- `Shift+Return` で ESC シーケンス (`\x1B\r`) を送信するキーバインドを追加

これにより Claude Code が Alacritty ターミナル上で正しく動作する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)