### PR TITLE
feat: Alacritty に option_as_alt = "Both" を追加

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -6,6 +6,7 @@ import = [
 [window]
 dimensions = { columns = 140, lines = 40 }
 padding = { x = 8, y = 4 }
+option_as_alt = "Both"
 
 [scrolling]
 history = 100000


### PR DESCRIPTION
## Summary
- `option_as_alt = "Both"` を `[window]` セクションに追加し、Option キーを Alt キーとして扱えるようにした

## Test plan
- [ ] Alacritty を再起動して Option キーが Alt キーとして動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)