### PR TITLE
fix: install.zsh の問題点を修正

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -17,6 +17,13 @@ else
   echo "Homebrew is already installed."
 fi
 
+# Add Homebrew to PATH (required on Apple Silicon immediately after install)
+if [[ -f /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -f /usr/local/bin/brew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
 # Install git
 if ! command_exists git; then
   echo "Installing git..."
@@ -44,6 +51,14 @@ else
   echo "Repository already exists at $CLONE_DIR."
 fi
 
+# Initialize git submodules
+echo "Initializing git submodules..."
+git -C "$CLONE_DIR" submodule update --init --recursive
+if [ $? -ne 0 ]; then
+  echo "Failed to initialize git submodules."
+  exit 1
+fi
+
 # Install zplug
 if [[ -z "$(typeset -f zplug)" && ! -d "$HOME/.zplug" ]]; then
   echo "Installing zplug..."
@@ -64,16 +79,10 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-source ~/.zshrc
-
 # Verify installations
 echo "Verifying installations..."
 command_exists brew && echo "Homebrew installation verified."
 [[ -n "$(typeset -f zplug)" ]] && echo "zplug installation verified."
-
-# Update and upgrade Homebrew
-brew update
-brew upgrade
 
 # Install Homebrew packages
 brew bundle --global

--- a/install.zsh
+++ b/install.zsh
@@ -5,7 +5,15 @@ command_exists() {
   command -v "$1" &>/dev/null
 }
 
-# Install Homebrew
+# Add Homebrew to PATH first (before checking if it's installed)
+# This handles the case where brew is installed but not yet in PATH
+if [[ -f /opt/homebrew/bin/brew ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -f /usr/local/bin/brew ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
+# Install Homebrew if still not available
 if ! command_exists brew; then
   echo "Installing Homebrew..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -13,15 +21,14 @@ if ! command_exists brew; then
     echo "Failed to install Homebrew."
     exit 1
   fi
+  # Add to PATH after installation
+  if [[ -f /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -f /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
 else
   echo "Homebrew is already installed."
-fi
-
-# Add Homebrew to PATH (required on Apple Silicon immediately after install)
-if [[ -f /opt/homebrew/bin/brew ]]; then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-elif [[ -f /usr/local/bin/brew ]]; then
-  eval "$(/usr/local/bin/brew shellenv)"
 fi
 
 # Install git
@@ -52,6 +59,10 @@ else
 fi
 
 # Initialize git submodules
+if [[ ! -d "$CLONE_DIR/.git" ]]; then
+  echo "$CLONE_DIR is not a git repository. Please remove it and re-run this script."
+  exit 1
+fi
 echo "Initializing git submodules..."
 git -C "$CLONE_DIR" submodule update --init --recursive
 if [ $? -ne 0 ]; then

--- a/install.zsh
+++ b/install.zsh
@@ -64,6 +64,12 @@ if ! git -C "$CLONE_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "$CLONE_DIR is not a git repository. Please remove it and re-run this script."
   exit 1
 fi
+ACTUAL_REPO_URL="$(git -C "$CLONE_DIR" remote get-url origin 2>/dev/null)"
+if [ "$ACTUAL_REPO_URL" != "$REPO_URL" ]; then
+  echo "$CLONE_DIR is not the expected repository ($REPO_URL)."
+  echo "Please remove it and re-run this script."
+  exit 1
+fi
 echo "Initializing git submodules..."
 git -C "$CLONE_DIR" submodule update --init --recursive
 if [ $? -ne 0 ]; then

--- a/install.zsh
+++ b/install.zsh
@@ -5,13 +5,18 @@ command_exists() {
   command -v "$1" &>/dev/null
 }
 
+# Add Homebrew to PATH if brew binary is executable at a known location
+setup_brew_env() {
+  if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+}
+
 # Add Homebrew to PATH first (before checking if it's installed)
 # This handles the case where brew is installed but not yet in PATH
-if [[ -f /opt/homebrew/bin/brew ]]; then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-elif [[ -f /usr/local/bin/brew ]]; then
-  eval "$(/usr/local/bin/brew shellenv)"
-fi
+setup_brew_env
 
 # Install Homebrew if still not available
 if ! command_exists brew; then
@@ -22,11 +27,7 @@ if ! command_exists brew; then
     exit 1
   fi
   # Add to PATH after installation
-  if [[ -f /opt/homebrew/bin/brew ]]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-  elif [[ -f /usr/local/bin/brew ]]; then
-    eval "$(/usr/local/bin/brew shellenv)"
-  fi
+  setup_brew_env
 else
   echo "Homebrew is already installed."
 fi
@@ -59,7 +60,7 @@ else
 fi
 
 # Initialize git submodules
-if [[ ! -d "$CLONE_DIR/.git" ]]; then
+if ! git -C "$CLONE_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "$CLONE_DIR is not a git repository. Please remove it and re-run this script."
   exit 1
 fi

--- a/link.zsh
+++ b/link.zsh
@@ -42,7 +42,7 @@ create_symlink() {
 
 # Handle regular dotfiles
 for file in $script_dir/.*; do
-    baseName="$(basename "$file")" 
+    baseName="$(basename "$file")"
 
     # Exclude ignore files and directories
     if [[ $baseName == "."

--- a/link.zsh
+++ b/link.zsh
@@ -1,3 +1,5 @@
+#!/bin/zsh
+
 script_dir=$(cd "$(dirname "$0")" && pwd)
 
 # Parse options
@@ -43,9 +45,12 @@ for file in $script_dir/.*; do
     baseName="$(basename "$file")" 
 
     # Exclude ignore files and directories
-    if [[ $baseName == "." 
-        || $baseName == ".." 
-        || $baseName == ".git" 
+    if [[ $baseName == "."
+        || $baseName == ".."
+        || $baseName == ".git"
+        || $baseName == ".gitignore"
+        || $baseName == ".gitmodules"
+        || $baseName == ".kiri"
         || $baseName == ".config" ]]; then
         continue
     fi


### PR DESCRIPTION
## Summary

### install.zsh
- Apple Silicon 対応: Homebrew インストール直後に `brew shellenv` で PATH を設定。未設定だと後続の `brew install git` などが `command not found` になる
- `git submodule update --init --recursive` を追加。`.config/alacritty/theme` サブモジュールがクローン後に初期化されていなかった
- `source ~/.zshrc` を削除。非インタラクティブ環境では zplug や p10k の読み込みでエラーになるリスクがあり、次回シェル起動時に自動で読まれるため不要
- `brew update` / `brew upgrade` を削除。新規セットアップ時は不要で、全パッケージの更新により時間がかかる

### link.zsh
- shebang (`#!/bin/zsh`) を追加
- `.gitignore` をシンボリックリンク対象から除外（リポジトリ用 ignore であり、グローバル gitignore として意図されていない）
- `.gitmodules` をシンボリックリンク対象から除外（git 内部ファイル）
- `.kiri` をシンボリックリンク対象から除外（Claude Code kiri ツールのインデックスデータ）

## Test plan
- [ ] Intel Mac で `install.zsh` を実行してエラーなく完了することを確認
- [ ] Apple Silicon Mac で `install.zsh` を実行してエラーなく完了することを確認
- [ ] クローン後に `.config/alacritty/theme` サブモジュールが初期化されていることを確認
- [ ] `link.zsh` 実行後に `~/.gitignore`、`~/.gitmodules`、`~/.kiri` が作成されていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)