### PR TITLE
chore: remove --verbose flag from zplug load

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -17,7 +17,7 @@ fi
 
 # Then, source plugins and add commands to $PATH
 # Make sure to use double quotes
-zplug load --verbose
+zplug load
 
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
 # Initialization code that may require console input (password prompts, [y/n]


### PR DESCRIPTION
## Summary

- `zplug load --verbose` から `zplug load` に変更し、起動時の冗長な出力を抑制

## Test plan

- [ ] シェル起動時に不要なプラグインロードログが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)