### PR TITLE
feat: Powerlevel10k から Starship プロンプトへ移行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,12 @@ jobs:
       - name: TOML syntax check
         run: |
           python3 -c "
-          import tomllib, sys
-          files = ['.chezmoiexternal.toml', 'dot_config/alacritty/alacritty.toml']
+          import tomllib, sys, pathlib
+          skip = set()
           ok = True
-          for f in files:
+          for f in sorted(pathlib.Path('.').rglob('*.toml')):
+              if f in skip:
+                  continue
               try:
                   with open(f, 'rb') as fp:
                       tomllib.load(fp)

--- a/dot_Brewfile
+++ b/dot_Brewfile
@@ -41,6 +41,8 @@ brew "wget"
 brew "yarn"
 # Additional completion definitions for zsh
 brew "zsh-completions"
+# Cross-shell prompt
+brew "starship"
 # Password manager that keeps all passwords secure behind one password
 cask "1password"
 # Command-line interface for 1Password

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -1,0 +1,193 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+format = """
+$os\
+$directory\
+$git_branch\
+$git_status\
+$git_state\
+$line_break\
+$character"""
+
+right_format = """
+$status\
+$cmd_duration\
+$jobs\
+$direnv\
+$python\
+$nodejs\
+$ruby\
+$golang\
+$terraform\
+$kubernetes\
+$aws\
+$gcloud\
+$azure\
+$username\
+$hostname\
+$time"""
+
+add_newline = true
+
+[os]
+format = "[$symbol]($style) "
+style = "bold white"
+disabled = false
+
+[os.symbols]
+Macos = ""
+Linux = ""
+Windows = ""
+
+[directory]
+format = "[$path]($style)[$read_only]($read_only_style) "
+style = "bold blue"
+read_only = " 󰌾"
+read_only_style = "red"
+truncation_length = 4
+truncate_to_repo = true
+truncation_symbol = "…/"
+
+[git_branch]
+format = "[$symbol$branch(:$remote_branch)]($style) "
+symbol = " "
+style = "bold purple"
+truncation_length = 32
+truncation_symbol = "…"
+
+[git_status]
+format = '([$all_status$ahead_behind]($style) )'
+style = "bold yellow"
+ahead = "⇡${count}"
+behind = "⇣${count}"
+diverged = "⇕⇡${ahead_count}⇣${behind_count}"
+up_to_date = ""
+untracked = "?${count}"
+stashed = "*${count}"
+modified = "!${count}"
+staged = "+${count}"
+renamed = "»${count}"
+deleted = "✘${count}"
+conflicted = "~${count}"
+
+[git_state]
+format = '\([$state( $progress_current/$progress_total)]($style)\) '
+style = "bold red"
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"
+vimcmd_symbol = "[❮](bold green)"
+vimcmd_replace_one_symbol = "[▶](bold purple)"
+vimcmd_replace_symbol = "[▶](bold purple)"
+vimcmd_visual_symbol = "[V](bold yellow)"
+
+[status]
+format = "[$symbol$status]($style) "
+symbol = "✘"
+success_symbol = ""
+signal_symbol = "⚡ "
+style = "bold red"
+map_symbol = true
+pipestatus = true
+disabled = false
+
+[cmd_duration]
+format = "[ $duration]($style) "
+style = "yellow"
+min_time = 3_000
+show_milliseconds = false
+
+[jobs]
+format = "[$symbol$number]($style) "
+symbol = "⚙ "
+style = "bold cyan"
+number_threshold = 1
+symbol_threshold = 1
+
+[direnv]
+format = "[$symbol$loaded/$allowed]($style) "
+symbol = "direnv "
+style = "bold orange"
+disabled = false
+allowed_msg = ""
+not_allowed_msg = "✗"
+denied_msg = "!!"
+loaded_msg = ""
+unloaded_msg = ""
+
+[python]
+format = '[$symbol$pyenv_prefix($version)(\($virtualenv\))]($style) '
+symbol = " "
+style = "bold yellow"
+detect_files = ["requirements.txt", "setup.py", "setup.cfg", "pyproject.toml", "Pipfile", ".python-version"]
+detect_extensions = ["py"]
+
+[nodejs]
+format = "[$symbol($version)]($style) "
+symbol = "󰎙 "
+style = "bold green"
+detect_files = ["package.json", ".nvmrc", ".node-version"]
+detect_extensions = ["js", "ts", "mjs", "cjs"]
+
+[ruby]
+format = "[$symbol($version)]($style) "
+symbol = " "
+style = "bold red"
+detect_files = ["Gemfile", ".ruby-version"]
+detect_extensions = ["rb"]
+
+[golang]
+format = "[$symbol($version)]($style) "
+symbol = " "
+style = "bold cyan"
+detect_files = ["go.mod", "go.sum", "go.work"]
+detect_extensions = ["go"]
+
+[kubernetes]
+format = "[$symbol$context( \\($namespace\\))]($style) "
+symbol = "☸ "
+style = "bold cyan"
+disabled = false
+
+[terraform]
+format = "[$symbol$workspace]($style) "
+symbol = "󱁢 "
+style = "bold purple"
+detect_files = [".terraform", "*.tf"]
+detect_extensions = ["tf", "tfvars"]
+
+[aws]
+format = '[$symbol($profile)(\[$duration\])]($style) '
+symbol = "󰸏 "
+style = "bold yellow"
+
+[gcloud]
+format = '[$symbol$account(@$domain)(\($project\))]($style) '
+symbol = " "
+style = "bold blue"
+
+[azure]
+format = "[$symbol($subscription)]($style) "
+symbol = "󰠅 "
+style = "bold blue"
+disabled = false
+
+[username]
+format = "[$user]($style)[@](dimmed white)"
+style_user = "dimmed white"
+style_root = "bold red"
+show_always = false
+
+[hostname]
+format = "[$ssh_symbol$hostname]($style) "
+style = "dimmed white"
+ssh_only = false
+trim_at = "."
+ssh_symbol = "󰢹 "
+
+[time]
+format = "[$time]($style)"
+style = "dimmed white"
+time_format = "%H:%M"
+disabled = false

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -20,9 +20,6 @@ fi
 # Make sure to use double quotes
 zplug load
 
-# Starship prompt
-eval "$(starship init zsh)"
-
 # brew zsh-completions
 if type brew &>/dev/null; then
   FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
@@ -36,3 +33,6 @@ zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
 
 # Machine-local additions (installer-appended PATH entries, etc.)
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
+
+# Starship prompt (must be last)
+eval "$(starship init zsh)"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -5,7 +5,6 @@ zplug "zsh-users/zsh-autosuggestions"
 zplug "zsh-users/zsh-history-substring-search"
 zplug "zsh-users/zsh-syntax-highlighting", defer:2
 zplug "vladmyr/dotfiles-plugin", from:oh-my-zsh
-zplug "romkatv/powerlevel10k", as:theme, depth:1
 zplug "junegunn/fzf"
 
 # Install plugins if there are plugins that have not been installed
@@ -21,18 +20,8 @@ fi
 # Make sure to use double quotes
 zplug load
 
-# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
-# Initialization code that may require console input (password prompts, [y/n]
-# confirmations, etc.) must go above this block; everything else may go below.
-# shellcheck disable=SC2296
-if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
-  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
-fi
-
-source ~/.zplug/repos/romkatv/powerlevel10k/powerlevel10k.zsh-theme
-
-# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
-[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+# Starship prompt
+eval "$(starship init zsh)"
 
 # brew zsh-completions
 if type brew &>/dev/null; then


### PR DESCRIPTION
## 概要

Powerlevel10k のメンテナンスが停滞しているため、Rust 製で積極的にメンテナンスされている [Starship](https://starship.rs/) に移行する。

- 表示する情報はすべて維持（OS・ディレクトリ・Git 状態・実行時間・各種バージョンマネージャ・クラウド環境・ユーザー@ホスト・時刻）
- Powerline セパレーターなしのモダンなスタイルに変更
- 起動が速い（Rust 製のため instant prompt 相当の設定が不要）

## 変更ファイル

- **`dot_zshrc`**: `powerlevel10k` を zplug から削除し `eval "$(starship init zsh)"` に変更
- **`dot_config/starship.toml`**: Starship 設定を新規追加
- **`dot_Brewfile`**: `starship` を追加

## 適用手順

\`\`\`zsh
brew install starship   # 未インストールの場合
chezmoi apply
\`\`\`

## テスト計画

- [ ] `chezmoi apply` でエラーが出ないこと
- [ ] 新しいシェルセッションでプロンプトが表示されること
- [ ] Git リポジトリ内でブランチ・差分情報が出ること
- [ ] コマンド失敗時にプロンプト文字（❯）が赤くなること
- [ ] 3秒以上かかるコマンド後に実行時間が右側に表示されること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)