### PR TITLE
feat: Ghostty の window padding と終了動作を設定

### DIFF
--- a/dot_config/ghostty/config.ghostty
+++ b/dot_config/ghostty/config.ghostty
@@ -8,9 +8,13 @@ theme = Monokai Pro
 
 window-height = 45
 window-width = 180
-window-padding-x = 2
+window-padding-x = 8
+window-padding-y = 4,8
+window-padding-balance = true
 
 link-url = true
+
+quit-after-last-window-closed
 
 auto-update = download
 auto-update-channel = stable

--- a/dot_config/ghostty/config.ghostty
+++ b/dot_config/ghostty/config.ghostty
@@ -14,7 +14,7 @@ window-padding-balance = true
 
 link-url = true
 
-quit-after-last-window-closed
+quit-after-last-window-closed = true
 
 auto-update = download
 auto-update-channel = stable


### PR DESCRIPTION
## 変更内容

- `window-padding-x` を 2 → 8 に拡大し、左右の余白を増やした
- `window-padding-y = 4,8` を追加（上: 4px、下: 8px の非対称パディング）
- `window-padding-balance = true` を追加（Split ペイン使用時のパディング自動バランス調整）
- `quit-after-last-window-closed` を追加（全ウィンドウを閉じると Ghostty プロセスを終了）

## テスト計画

- [ ] `chezmoi apply` でファイルが `~/.config/ghostty/config.ghostty` に正しく適用されること
- [ ] Ghostty 再起動後に padding が意図した見た目になっていること
- [ ] 最後のウィンドウを閉じたとき Ghostty が終了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)