### PR TITLE
docs: Ubuntu/WSL 向けインストールワンライナーを README に追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,22 @@
 
 ## インストール
 
+### macOS
+
 1. 以下のコマンドを実行する:
 
    ```zsh
    zsh -c "$(curl -fsSL https://raw.githubusercontent.com/cyber-gene/dotfiles/main/install.zsh)"
+   ```
+
+### Ubuntu / WSL
+
+Homebrew を使わず、`apt` で最小限の依存パッケージのみをインストールする。
+
+1. 以下のコマンドを実行する:
+
+   ```bash
+   bash -c "$(curl -fsSL https://raw.githubusercontent.com/cyber-gene/dotfiles/main/install-ubuntu.sh)"
    ```
 
 ## メンテナンス


### PR DESCRIPTION
## 概要

- `install-ubuntu.sh` のワンライナーを README の「インストール」セクションに追記
- 既存の macOS 手順と並べて `### macOS` / `### Ubuntu / WSL` で見出しを分割

## 確認項目

- [ ] ワンライナーの URL が正しい
- [ ] macOS セクションに影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)