### PR TITLE
docs: CLAUDE.md の Language 節にオーナー判定ルールを追加

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -8,10 +8,18 @@ Unless a project-level CLAUDE.md specifies otherwise, follow **GitHub Flow**:
 
 ## Language
 
+リモート URL が `github.com/cyber-gene/` を含む場合は自分のリポジトリとみなす。それ以外は他者のリポジトリとして扱う。
+
+### 自分のリポジトリ
+
 - コミットメッセージ、PR タイトル・サマリー・コードレビューコメントは**日本語**で書く
 - コードコメントは**既存コードの慣例に従う**
 - ブランチ名のプレフィックス（`feature/`, `fix/`, `chore/` など）は英語のままにする
   - 例: `feature/ログイン機能追加`, `fix/nullポインタクラッシュ修正`
+
+### 他者のリポジトリ
+
+- コミットメッセージ・PR タイトル・サマリー・コードレビューコメント・コードコメントのすべてをそのリポジトリの既存の慣例に従う
 
 ## Code Design
 


### PR DESCRIPTION
## 変更内容

- リモート URL が `github.com/cyber-gene/` を含む場合を「自分のリポジトリ」と判定するルールを追加
- 自分のリポジトリ：従来通り日本語でコミット・PR・レビューコメントを書く
- 他者のリポジトリ：コミット・PR・コードコメントすべてそのリポジトリの慣例に従う

## テスト計画

- [ ] `chezmoi apply` で `~/.claude/CLAUDE.md` に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)