### PR TITLE
feat: starship に docker_context・dotnet モジュールを追加し各種設定を整備

### DIFF
--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -18,6 +18,8 @@ $python\
 $nodejs\
 $ruby\
 $golang\
+$dotnet\
+$docker_context\
 $terraform\
 $kubernetes\
 $aws\
@@ -35,9 +37,65 @@ style = "bold white"
 disabled = false
 
 [os.symbols]
-Macos = ""
-Linux = ""
-Windows = ""
+AIX = " "
+AlmaLinux = " "
+Alpaquita = " "
+Alpine = " "
+ALTLinux = " "
+Amazon = " "
+Android = " "
+AOSC = " "
+Arch = " "
+Artix = " "
+Bluefin = " "
+CachyOS = " "
+CentOS = " "
+Debian = " "
+DragonFly = " "
+Elementary = " "
+Emscripten = " "
+EndeavourOS = " "
+Fedora = " "
+FreeBSD = " "
+Garuda = " "
+Gentoo = " "
+HardenedBSD = "󰞌 "
+Illumos = " "
+InstantOS = " "
+Ios = "󰀷 "
+Kali = " "
+Linux = " "
+Mabox = " "
+Macos = " "
+Manjaro = " "
+Mariner = " "
+MidnightBSD = " "
+Mint = " "
+NetBSD = " "
+NixOS = " "
+Nobara = " "
+OpenBSD = " "
+OpenCloudOS = " "
+openEuler = " "
+openSUSE = " "
+OracleLinux = "󰺡 "
+PikaOS = " "
+Pop = " "
+Raspbian = " "
+Redhat = "󱄛 "
+RedHatEnterprise = "󱄛 "
+Redox = "󰀘 "
+RockyLinux = " "
+Solus = " "
+SUSE = " "
+Ubuntu = " "
+Ultramarine = " "
+Unknown = " "
+Uos = " "
+Void = " "
+Windows = "󰍲 "
+Zorin = " "
+
 
 [directory]
 format = "[$path]($style)[$read_only]($read_only_style) "
@@ -74,6 +132,9 @@ conflicted = "~${count}"
 format = '\([$state( $progress_current/$progress_total)]($style)\) '
 style = "bold red"
 
+[git_commit]
+tag_symbol = '  '
+
 [character]
 success_symbol = "[❯](bold green)"
 error_symbol = "[❯](bold red)"
@@ -107,7 +168,7 @@ symbol_threshold = 1
 
 [direnv]
 format = "[$symbol$loaded/$allowed]($style) "
-symbol = "direnv "
+symbol = " "
 style = "bold orange"
 disabled = false
 allowed_msg = ""
@@ -116,23 +177,37 @@ denied_msg = "!!"
 loaded_msg = ""
 unloaded_msg = ""
 
+[docker_context]
+format = "[$symbol$context]($style) "
+symbol = " "
+style = "bold blue"
+detect_files = ["docker-compose.yml", "docker-compose.yaml", "Dockerfile"]
+only_with_files = true
+
+[dotnet]
+format = "[$symbol($version)(  $tfm)]($style) "
+symbol = " "
+style = "bold purple"
+detect_files = ["global.json", "project.json", "Directory.Build.props", "Directory.Build.targets", "Packages.props"]
+detect_extensions = ["csproj", "fsproj", "xproj", "sln"]
+
 [python]
 format = '[$symbol$pyenv_prefix($version)(\($virtualenv\))]($style) '
-symbol = " "
+symbol = " "
 style = "bold yellow"
 detect_files = ["requirements.txt", "setup.py", "setup.cfg", "pyproject.toml", "Pipfile", ".python-version"]
 detect_extensions = ["py"]
 
 [nodejs]
 format = "[$symbol($version)]($style) "
-symbol = "󰎙 "
+symbol = " "
 style = "bold green"
 detect_files = ["package.json", ".nvmrc", ".node-version"]
 detect_extensions = ["js", "ts", "mjs", "cjs"]
 
 [ruby]
 format = "[$symbol($version)]($style) "
-symbol = " "
+symbol = " "
 style = "bold red"
 detect_files = ["Gemfile", ".ruby-version"]
 detect_extensions = ["rb"]
@@ -146,7 +221,7 @@ detect_extensions = ["go"]
 
 [kubernetes]
 format = "[$symbol$context( \\($namespace\\))]($style) "
-symbol = "☸ "
+symbol = "󱃾 "
 style = "bold cyan"
 disabled = false
 
@@ -159,12 +234,12 @@ detect_extensions = ["tf", "tfvars"]
 
 [aws]
 format = '[$symbol($profile)(\[$duration\])]($style) '
-symbol = "󰸏 "
+symbol = " "
 style = "bold yellow"
 
 [gcloud]
 format = '[$symbol$account(@$domain)(\($project\))]($style) '
-symbol = " "
+symbol = "󱇶 "
 style = "bold blue"
 
 [azure]

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -6,6 +6,7 @@ $directory\
 $git_branch\
 $git_status\
 $git_state\
+$git_commit\
 $line_break\
 $character"""
 

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -181,7 +181,7 @@ unloaded_msg = ""
 format = "[$symbol$context]($style) "
 symbol = " "
 style = "bold blue"
-detect_files = ["docker-compose.yml", "docker-compose.yaml", "Dockerfile"]
+detect_files = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml", "Dockerfile"]
 only_with_files = true
 
 [dotnet]


### PR DESCRIPTION
## 変更内容

- `[docker_context]` モジュールを追加
  - `format`, `style`（bold blue）, `detect_files`, `only_with_files` を設定
- `[dotnet]` モジュールを追加
  - `format`（バージョン + TFM 表示）, `style`（bold purple）, `detect_files`, `detect_extensions` を設定
- `right_format` に `$dotnet`・`$docker_context` を追加（golang の直後、terraform の前）
- `[os.symbols]` を全 OS シンボルに拡張（3 エントリ → 全 OS 対応）
- 各言語・ツールモジュールのシンボルを Nerd Font アイコンに統一（python, nodejs, ruby, kubernetes, aws, gcloud）
- `[git_commit]` セクション追加（tag_symbol 設定）
- `[direnv]` シンボルを `"direnv "` から Nerd Font アイコンに変更

## テスト

- `chezmoi apply` で `~/.config/starship.toml` に適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)